### PR TITLE
Load Fabric.js only when customizing product

### DIFF
--- a/app/customize-product/[id]/page.tsx
+++ b/app/customize-product/[id]/page.tsx
@@ -32,6 +32,7 @@ import { ProductCustomizer } from '@/components/product-customizer'
 import { toast } from 'sonner'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { AddressSelector } from '@/components/address-selector'
+import Script from 'next/script'
 
 const supabase = createClient()
 
@@ -385,7 +386,9 @@ export default function CustomizeProductPage () {
   const thicknessOptions = getUniqueAttributes(products, 'CanvasThicknessType')
 
   return (
-    <div className='min-h-[calc(100vh-3.5rem)] py-8'>
+    <>
+      <Script src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js" strategy="beforeInteractive" />
+      <div className='min-h-[calc(100vh-3.5rem)] py-8'>
       <div className='container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
         <div className='grid grid-cols-1 lg:grid-cols-2 gap-8'>
           {/* Left side – Canvas Editor */}
@@ -602,5 +605,6 @@ export default function CustomizeProductPage () {
         </div>
       </div>
     </div>
+    </>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,6 @@ import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { Header } from "@/components/header";
 import { AuthProvider } from "@/components/auth-provider";
-import Script from "next/script";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -23,13 +22,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head>
-        <Script
-          src="https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js"
-          strategy="beforeInteractive"
-          crossOrigin="anonymous"
-        />
-      </head>
+      <head />
       <body className={`${inter.className} min-h-screen flex flex-col`}>
         <ThemeProvider
           attribute="class"


### PR DESCRIPTION
## Summary
- remove global Fabric.js script include
- only load Fabric.js on the customize product page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840be3105608326b7fe0f6cd48c1388