### PR TITLE
Fix price calculation and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .env
+dist-test

--- a/lib/pricing.ts
+++ b/lib/pricing.ts
@@ -15,7 +15,7 @@ export interface ProductPrice {
 }
 
 export function calculateFinalPrice (price: ProductPrice): number {
-  let finalPrice = 16.83
+  let finalPrice = price.basePrice
 
   // Appliquer la marge
   if (price.margin) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node tests/pricing.test.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/tests/pricing.test.js
+++ b/tests/pricing.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Compile the TypeScript source for testing
+const libPath = path.join(__dirname, '../lib/pricing.ts');
+const outDir = path.join(__dirname, '../dist-test');
+execSync(`tsc ${libPath} --target es2017 --module commonjs --outDir ${outDir}`, { stdio: 'inherit' });
+
+const pricing = require(path.join(outDir, 'pricing.js'));
+
+function runTests() {
+  // No margin or discount
+  let price = pricing.calculateFinalPrice({ basePrice: 100, currency: 'USD' });
+  assert.strictEqual(price, 100);
+
+  // Margin only
+  price = pricing.calculateFinalPrice({ basePrice: 100, currency: 'USD', margin: 0.1 });
+  assert.strictEqual(price, 110);
+
+  // Discount only
+  price = pricing.calculateFinalPrice({ basePrice: 200, currency: 'USD', discount: 0.2 });
+  assert.strictEqual(price, 160);
+
+  // Margin and discount
+  price = pricing.calculateFinalPrice({ basePrice: 50, currency: 'USD', margin: 0.2, discount: 0.1 });
+  assert.strictEqual(price, 54);
+
+  console.log('All tests passed!');
+}
+
+runTests();


### PR DESCRIPTION
## Summary
- fix `calculateFinalPrice` so it starts from the provided `basePrice`
- ignore `dist-test` build output
- add basic unit tests for pricing calculations
- expose `npm test` script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840bccc783c8326a9b658c0a851958d